### PR TITLE
Updated Toolbox

### DIFF
--- a/Toolbox_new/app/page.tsx
+++ b/Toolbox_new/app/page.tsx
@@ -21,8 +21,10 @@ export interface CartItem {
   brand: string
   itemType: string
   location: string
+  // Balance is automatically calculated by the database as (in_qty - out_qty)
   balance: number
   quantity: number
+  // Status is automatically calculated by the database trigger based on balance vs min_stock
   status: "in-stock" | "low-stock" | "out-of-stock"
 }
 

--- a/Toolbox_new/components/cart-view.tsx
+++ b/Toolbox_new/components/cart-view.tsx
@@ -119,19 +119,17 @@ export function CartView({ items, onUpdateQuantity, onRemoveItem, onReturnToBrow
     try {
       console.log("[v0] Starting checkout process...")
 
+      // Trust the API/database to calculate balance and item_status after checkout
+      // Only send the necessary data: item_no, quantity, and item_name
       const itemUpdates = items.map((item) => ({
         id: item.id,
         name: item.name,
+        quantity: item.quantity,
+        // Include these for logging purposes only (not used by API)
         brand: item.brand,
         itemType: item.itemType,
         location: item.location,
-        balance: Math.max(0, item.balance - item.quantity), // Reduce balance by quantity taken
-        status:
-          item.balance - item.quantity > 10
-            ? "in-stock"
-            : item.balance - item.quantity > 0
-              ? "low-stock"
-              : "out-of-stock",
+        balance: item.balance, // Current balance for transaction logging
       }))
 
       console.log("[v0] Item updates prepared:", itemUpdates)

--- a/Toolbox_new/lib/barcode-scanner.ts
+++ b/Toolbox_new/lib/barcode-scanner.ts
@@ -4,13 +4,19 @@
  */
 
 // Product type definition
+// Balance and status are calculated by the database and should not be modified client-side
 export interface Product {
   id: string
   name: string
   brand: string
   itemType: string
   location: string
+  // Balance is automatically calculated by the database as (in_qty - out_qty)
   balance: number
+  // Status is automatically calculated by the database trigger based on balance vs min_stock
+  // "Out of Stock" -> balance <= 0
+  // "Low in Stock" -> 0 < balance < min_stock
+  // "In Stock" -> balance >= min_stock
   status: "in-stock" | "low-stock" | "out-of-stock"
 }
 

--- a/Toolbox_new/lib/validation.ts
+++ b/Toolbox_new/lib/validation.ts
@@ -57,13 +57,16 @@ export const SearchQuerySchema = z.string()
   .regex(/^[A-Za-z0-9\s._-]*$/, "Search query contains invalid characters")
 
 // API response validation schemas
+// Note: balance and item_status are calculated by the database and should be trusted as-is
 export const ApiItemSchema = z.object({
   item_no: z.union([z.string(), z.number()]).transform(String),
   item_name: z.string().min(1, "Item name is required"),
   brand: z.string().optional().default("Unknown Brand"),
   item_type: z.string().optional().default("General"),
   location: z.string().optional().default("Unknown Location"),
+  // balance is automatically calculated by database as (in_qty - out_qty)
   balance: z.number().min(0, "Balance cannot be negative"),
+  // item_status is automatically set by database trigger based on balance vs min_stock
   item_status: z.string().optional(),
 })
 


### PR DESCRIPTION
This pull request refactors how inventory balance and status are handled across the toolbox app. The main change is to trust the database to calculate both the `balance` (as in_qty - out_qty) and the `status` (using a database trigger based on balance vs min_stock), rather than recalculating these values client-side. This simplifies the code and ensures consistency with the backend.

**Inventory calculation and status handling:**

* Updated the `Product` and `CartItem` interfaces to clarify that `balance` and `status` are calculated by the database and should not be modified by the client. Added comments explaining the calculation logic. [[1]](diffhunk://#diff-f7334f7ee10998395a7a328a42a760b0426e735705a2003126de06936ef6e8b1R7-R19) [[2]](diffhunk://#diff-e9a2524fae903135e0824b2c34369739badc22e9d9b877fa91cd33763792402cR24-R27)
* Refactored the API response transformation in `dashboard-view.tsx` to trust the database-calculated `balance` and `item_status`, removing any client-side fallback logic for these fields.
* Modified the checkout logic in `cart-view.tsx` to send only the necessary fields to the API, relying on the backend to update `balance` and `status` after checkout, and logging the current `balance` for reference.

**Validation schema updates:**

* Updated the API item validation schema in `validation.ts` to document that `balance` and `item_status` are set by the database and should be trusted as-is.